### PR TITLE
Add support for ListSeparator after const (closes creditkarma/thrift-parser#12)

### DIFF
--- a/tests/test-parse.expection.json
+++ b/tests/test-parse.expection.json
@@ -60,6 +60,14 @@
     "C6": {
       "type": "bool",
       "value": false
+    },
+    "C8": {
+      "type": "bool",
+      "value": true
+    },
+    "C9": {
+      "type": "bool",
+      "value": false
     }
   },
   "enum": {

--- a/tests/test.thrift
+++ b/tests/test.thrift
@@ -14,6 +14,8 @@ const list<i32> C3 = [ 1, 2, 3 ]
 const map<i32, string> C4 = { 1: 'a', 2: 'b', 3: 'c' }
 const bool C5 = true
 const bool C6 = false
+const bool C8 = true;
+const bool C9 = false,
 
 /**
  * Enum

--- a/thrift-parser.js
+++ b/thrift-parser.js
@@ -243,6 +243,7 @@ module.exports = (buffer, offset = 0) => {
     let type = readType();
     let name = readName();
     let value = readAssign();
+    readComma();
     return { subject, type, name, value };
   };
 


### PR DESCRIPTION
Whoops, submitted in the wrong place.