### PR TITLE
Adding support for some features

### DIFF
--- a/tests/test-parse.expection.json
+++ b/tests/test-parse.expection.json
@@ -2,6 +2,9 @@
   "namespace": {
     "php": {
       "serviceName": "hehe"
+    },
+    "*": {
+      "serviceName": "haha"
     }
   },
   "typedef": {

--- a/tests/test-parse.expection.json
+++ b/tests/test-parse.expection.json
@@ -60,6 +60,17 @@
     "C6": {
       "type": "bool",
       "value": false
+    },
+    "C7": {
+      "type": {
+        "name": "set",
+        "valueType": "i32"
+      },
+      "value": [
+        1,
+        2,
+        3
+      ]
     }
   },
   "enum": {
@@ -218,6 +229,36 @@
             "id": 2,
             "type": "Struct2",
             "name": "s2"
+          }
+        ],
+        "throws": [
+          {
+            "id": 1,
+            "type": "Exception1",
+            "name": "user_exception"
+          },
+          {
+            "id": 2,
+            "type": "Exception2",
+            "name": "system_exception"
+          }
+        ],
+        "oneway": false
+      },
+      "test2": {
+        "type": {
+          "name": "list",
+          "valueType": {
+            "name": "set",
+            "valueType": "Struct1"
+          }
+        },
+        "name": "test2",
+        "args": [
+          {
+            "id": 1,
+            "type": "Struct1",
+            "name": "s1"
           }
         ],
         "throws": [

--- a/tests/test-parse.expection.json
+++ b/tests/test-parse.expection.json
@@ -82,6 +82,14 @@
     "C9": {
       "type": "bool",
       "value": false
+    },
+    "C10": {
+      "type": "i16",
+      "value": 32767
+    },
+    "C11": {
+      "type": "i32",
+      "value": 2147483647
     }
   },
   "enum": {

--- a/tests/test-parse.expection.json
+++ b/tests/test-parse.expection.json
@@ -74,6 +74,14 @@
         2,
         3
       ]
+    },
+    "C8": {
+      "type": "bool",
+      "value": true
+    },
+    "C9": {
+      "type": "bool",
+      "value": false
     }
   },
   "enum": {

--- a/tests/test.thrift
+++ b/tests/test.thrift
@@ -14,6 +14,7 @@ const list<i32> C3 = [ 1, 2, 3 ]
 const map<i32, string> C4 = { 1: 'a', 2: 'b', 3: 'c' }
 const bool C5 = true
 const bool C6 = false
+const set<i32> C7 = [ 1, 2, 3 ]
 
 /**
  * Enum
@@ -66,6 +67,8 @@ service Service1 {
      * TEST
      */
     list<map<Struct1, Struct2>> test(1: Struct1 s1, 2: Struct2 s2)
+      throws (1: Exception1 user_exception, 2: Exception2 system_exception)
+    list<set<Struct1>> test2(1: Struct1 s1)
       throws (1: Exception1 user_exception, 2: Exception2 system_exception)
 }
 

--- a/tests/test.thrift
+++ b/tests/test.thrift
@@ -1,4 +1,5 @@
 namespace php hehe
+namespace * haha
 
 /******
  * Types

--- a/tests/test.thrift
+++ b/tests/test.thrift
@@ -16,6 +16,8 @@ const map<i32, string> C4 = { 1: 'a', 2: 'b', 3: 'c' }
 const bool C5 = true
 const bool C6 = false
 const set<i32> C7 = [ 1, 2, 3 ]
+const bool C8 = true;
+const bool C9 = false,
 
 /**
  * Enum

--- a/tests/test.thrift
+++ b/tests/test.thrift
@@ -18,6 +18,8 @@ const bool C6 = false
 const set<i32> C7 = [ 1, 2, 3 ]
 const bool C8 = true;
 const bool C9 = false,
+const i16 C10 = 0x7fff
+const i32 C11 = 0x7fffffff
 
 /**
  * Enum

--- a/thrift-parser.js
+++ b/thrift-parser.js
@@ -148,6 +148,23 @@ module.exports = (buffer, offset = 0) => {
     return value;
   };
 
+  const readScope = () => {
+    let i = 0;
+    let result = [];
+    let byte = buffer[offset];
+    while (
+      (byte >= 97 && byte <= 122) || // a-z
+      byte === 95 ||                 // _
+      (byte >= 65 && byte <= 90) ||  // A-Z
+      (byte >= 48 && byte <= 57) ||  // 0-9
+      (byte === 42)                  // *
+    ) byte = buffer[offset + ++i];
+    if (i === 0) throw 'Unexpected token';
+    let value = buffer.toString('utf8', offset, offset += i);
+    readSpace();
+    return value;
+  };
+
   const readNumberValue = () => {
     let result = [];
     for (;;) {
@@ -321,7 +338,7 @@ module.exports = (buffer, offset = 0) => {
 
   const readNamespace = () => {
     let subject = readKeyword('namespace');
-    let name = readName();
+    let name = readScope();
     let serviceName = readRefValue()['='].join('.');
     return { subject, name, serviceName };
   };

--- a/thrift-parser.js
+++ b/thrift-parser.js
@@ -260,6 +260,7 @@ module.exports = (buffer, offset = 0) => {
     let type = readType();
     let name = readName();
     let value = readAssign();
+    readComma();
     return { subject, type, name, value };
   };
 


### PR DESCRIPTION
This PR contains commits for:

* Adding a Set container to the fixture and expectations.
* Support for the `namespace *` syntax. - More work might need to go into this because the Thrift spec only seems to support a finite list of strings.
* Support for a ListSeparator (`,` or `;`) after a `const ...` declaration.
* Support for hexadecimal values. - I am also working to get e-notation support that might land before this PR is reviewed and I'll update if so.