### PR TITLE
Fix Union structure to match Struct and Exception (#50)

### DIFF
--- a/tests/test-parse.expection.json
+++ b/tests/test-parse.expection.json
@@ -222,26 +222,24 @@
     ]
   },
   "union": {
-    "Union1": {
-      "items": [
-        {
-          "id": 1,
-          "type": "string",
-          "name": "field1"
-        },
-        {
-          "id": 2,
-          "type": "int",
-          "name": "field2"
-        },
-        {
-          "id": 3,
-          "type": "string",
-          "name": "withOption",
-          "option": "required"
-        }
-      ]
-    }
+    "Union1": [
+      {
+        "id": 1,
+        "type": "string",
+        "name": "field1"
+      },
+      {
+        "id": 2,
+        "type": "int",
+        "name": "field2"
+      },
+      {
+        "id": 3,
+        "type": "string",
+        "name": "withOption",
+        "option": "required"
+      }
+    ]
   },
   "exception": {
     "Exception1": [

--- a/thrift-parser.js
+++ b/thrift-parser.js
@@ -535,6 +535,7 @@ module.exports = (source, offset = 0) => {
         switch (subject) {
           case 'exception':
           case 'struct':
+          case 'union':
             storage[subject][name] = block.items;
             break;
           default:


### PR DESCRIPTION
When my Union changes were merged, this wasn't caught.  This PR aligns the Union output with Structs & Exceptions.