### PR TITLE
Test fixes (#60)

### DIFF
--- a/tests/consts.js
+++ b/tests/consts.js
@@ -26,7 +26,7 @@ describe('consts', function() {
     done();
   });
 
-  it.skip('does not parse a const without assignment', function(done) {
+  it('does not parse a const without assignment', function(done) {
     const content = `
       const string test
     `;
@@ -190,8 +190,7 @@ describe('consts', function() {
     done();
   });
 
-  // TODO: this currently OOMs V8
-  it.skip('does not parse a const with a value wrapped in mixed-quotes', function(done) {
+  it('does not parse a const with a value wrapped in mixed-quotes', function(done) {
     const content = `
       const string test = "hello world'
     `;
@@ -237,7 +236,44 @@ describe('consts', function() {
     done();
   });
 
-  it.skip('does not parse an invalid Map type', function(done) {
+  it('parses a const for Map type with `;` separator (ListSeparator)', function(done) {
+    const content = `
+      const map<i32, string> test = { 1: 'a'; 2: 'b'; 3: 'c' }
+    `;
+
+    const expected = {
+      const: {
+        test: {
+          type: {
+            name: 'map',
+            keyType: 'i32',
+            valueType: 'string'
+          },
+          value: [
+            {
+              key: 1,
+              value: 'a'
+            },
+            {
+              key: 2,
+              value: 'b'
+            },
+            {
+              key: 3,
+              value: 'c'
+            }
+          ]
+        }
+      }
+    };
+
+    const ast = thriftParser(content);
+
+    expect(ast).toEqual(expected);
+    done();
+  });
+
+  it('does not parse an invalid Map type', function(done) {
     const content = `
       const map<i32> test = { 1: 'a', 2: 'b', 3: 'c' }
     `;
@@ -246,7 +282,7 @@ describe('consts', function() {
     done();
   });
 
-  it.skip('does not parse an invalid Map values', function(done) {
+  it('does not parse an invalid Map value', function(done) {
     const content = `
       const map<i32, string> test = [ 1, 2, 3]
     `;
@@ -278,7 +314,30 @@ describe('consts', function() {
     done();
   });
 
-  it.skip('does not parse an invalid Set type', function(done) {
+  it('parses a const for Set type with `;` separator (ListSeparator)', function(done) {
+    const content = `
+      const set<i32> test = [ 1; 2; 3 ]
+    `;
+
+    const expected = {
+      const: {
+        test: {
+          type: {
+            name: 'set',
+            valueType: 'i32'
+          },
+          value: [1, 2, 3]
+        }
+      }
+    };
+
+    const ast = thriftParser(content);
+
+    expect(ast).toEqual(expected);
+    done();
+  });
+
+  it('does not parse an invalid Set type', function(done) {
     const content = `
       const set<i32, string> test = [ 1, 2, 3 ]
     `;
@@ -287,7 +346,7 @@ describe('consts', function() {
     done();
   });
 
-  it.skip('does not parse an invalid Set values', function(done) {
+  it('does not parse an invalid Set value', function(done) {
     const content = `
       const set<i32> test = { 1: 'a', 2: 'b', 3: 'c' }
     `;
@@ -319,7 +378,30 @@ describe('consts', function() {
     done();
   });
 
-  it.skip('does not parse an invalid List type', function(done) {
+  it('parses a const for List type with `;` separator (ListSeparator)', function(done) {
+    const content = `
+      const list<i32> test = [ 1; 2; 3 ]
+    `;
+
+    const expected = {
+      const: {
+        test: {
+          type: {
+            name: 'list',
+            valueType: 'i32'
+          },
+          value: [1, 2, 3]
+        }
+      }
+    };
+
+    const ast = thriftParser(content);
+
+    expect(ast).toEqual(expected);
+    done();
+  });
+
+  it('does not parse an invalid List type', function(done) {
     const content = `
       const list<i32, string> test = [ 1, 2, 3 ]
     `;
@@ -328,7 +410,7 @@ describe('consts', function() {
     done();
   });
 
-  it.skip('does not parse an invalid List values', function(done) {
+  it('does not parse an invalid List value', function(done) {
     const content = `
       const list<i32> test = { 1: 'a', 2: 'b', 3: 'c' }
     `;

--- a/tests/enums.js
+++ b/tests/enums.js
@@ -68,8 +68,7 @@ describe('enums', function() {
     done();
   });
 
-  // TODO: fix values
-  it.skip('parses an enum without values', function(done) {
+  it('parses an enum without values', function(done) {
     const content = `
       enum Test {
         test1
@@ -102,8 +101,7 @@ describe('enums', function() {
     done();
   });
 
-  // TODO: fix values
-  it.skip('parses an enum with mixed values', function(done) {
+  it('parses an enum with mixed values', function(done) {
     const content = `
       enum Test {
         test1 = 1
@@ -476,7 +474,7 @@ describe('enums', function() {
     done();
   });
 
-  it.skip('does not parse an enum with a string value assignment', function(done) {
+  it('does not parse an enum with a string value assignment', function(done) {
     const content = `
       enum Test {
         test1 = 'test'
@@ -487,7 +485,7 @@ describe('enums', function() {
     done();
   });
 
-  it.skip('does not parse an enum with a decimal value assignment', function(done) {
+  it('does not parse an enum with a decimal value assignment', function(done) {
     const content = `
       enum Test {
         test1 = 1.2
@@ -498,7 +496,7 @@ describe('enums', function() {
     done();
   });
 
-  it.skip('does not parse an enum with an e-notation value assignment', function(done) {
+  it('does not parse an enum with an e-notation value assignment', function(done) {
     const content = `
       enum Test {
         test1 = 1e2
@@ -509,7 +507,7 @@ describe('enums', function() {
     done();
   });
 
-  it.skip('does not parse an enum with a Map value assignment', function(done) {
+  it('does not parse an enum with a Map value assignment', function(done) {
     const content = `
       enum Test {
         test1 = {'test':'test'}
@@ -520,7 +518,7 @@ describe('enums', function() {
     done();
   });
 
-  it.skip('does not parse an enum with a Set/List value assignment', function(done) {
+  it('does not parse an enum with a Set/List value assignment', function(done) {
     const content = `
       enum Test {
         test1 = [1,2,3]

--- a/tests/exceptions.js
+++ b/tests/exceptions.js
@@ -205,7 +205,7 @@ describe('exceptions', function() {
     done();
   });
 
-  it.skip('parses a exception containing a field with a hex FieldID', function(done) {
+  it('parses a exception containing a field with a hex FieldID', function(done) {
     const content = `
       exception Test {
         0x01: string test1
@@ -255,7 +255,7 @@ describe('exceptions', function() {
     done();
   });
 
-  it.skip('parses a exception containing a field with a positive FieldID with `+`', function(done) {
+  it('parses a exception containing a field with a positive FieldID with `+`', function(done) {
     const content = `
       exception Test {
         +1: string test1
@@ -266,7 +266,7 @@ describe('exceptions', function() {
       exception: {
         Test: [
           {
-            id: -1,
+            id: 1,
             type: 'string',
             name: 'test1'
           }
@@ -280,8 +280,7 @@ describe('exceptions', function() {
     done();
   });
 
-  // TODO: Remove undefined field in output
-  it.skip('parses a exception containing a field without a FieldID', function(done) {
+  it('parses a exception containing a field without a FieldID', function(done) {
     const content = `
       exception Test {
         string test1
@@ -305,7 +304,7 @@ describe('exceptions', function() {
     done();
   });
 
-  it.skip('parses a exception containing a field without a FieldID but with required', function(done) {
+  it('parses a exception containing a field without a FieldID but with required', function(done) {
     const content = `
       exception Test {
         required string test1
@@ -330,7 +329,7 @@ describe('exceptions', function() {
     done();
   });
 
-  it.skip('parses a exception containing mixed fields with/without a FieldID', function(done) {
+  it('parses a exception containing mixed fields with/without a FieldID', function(done) {
     const content = `
       exception Test {
         string test1
@@ -489,8 +488,7 @@ describe('exceptions', function() {
     done();
   });
 
-  // TODO: OOMs the VM
-  it.skip('does not parse a exception containing a field with invalid default', function(done) {
+  it('does not parse a exception containing a field with invalid default', function(done) {
     const content = `
       exception Test {
         1: string test = 'test
@@ -501,8 +499,7 @@ describe('exceptions', function() {
     done();
   });
 
-  // TODO: OOMs the VM
-  it.skip('does not parse a exception containing a field with default containing mixed quotes', function(done) {
+  it('does not parse a exception containing a field with default containing mixed quotes', function(done) {
     const content = `
       exception Test {
         1: string test = 'test"
@@ -535,7 +532,7 @@ describe('exceptions', function() {
     done();
   });
 
-  it.skip('does not parse a exception containing a field with decimal FieldID', function(done) {
+  it('does not parse a exception containing a field with decimal FieldID', function(done) {
     const content = `
       exception Test {
         1.2: string test
@@ -596,7 +593,7 @@ describe('exceptions', function() {
     done();
   });
 
-  it.skip('does not parse a exception containing a field with an invalid Map type', function(done) {
+  it('does not parse a exception containing a field with an invalid Map type', function(done) {
     const content = `
       exception Test {
         1: map<i16> test
@@ -607,7 +604,7 @@ describe('exceptions', function() {
     done();
   });
 
-  it.skip('does not parse a exception containing a field with a Map type but invalid default', function(done) {
+  it('does not parse a exception containing a field with a Map type but invalid default', function(done) {
     const content = `
       exception Test {
         1: map<i16, string> test = [1,2]
@@ -650,7 +647,7 @@ describe('exceptions', function() {
     done();
   });
 
-  it.skip('does not parse a exception containing a field with an invalid Set type', function(done) {
+  it('does not parse a exception containing a field with an invalid Set type', function(done) {
     const content = `
       exception Test {
         1: set<i16, string> test = [1,2]
@@ -661,7 +658,7 @@ describe('exceptions', function() {
     done();
   });
 
-  it.skip('does not parse a exception containing a field with a Set type but invalid default', function(done) {
+  it('does not parse a exception containing a field with a Set type but invalid default', function(done) {
     const content = `
       exception Test {
         1: set<i16> test = { 1: 'a', 2: 'b' }
@@ -704,7 +701,7 @@ describe('exceptions', function() {
     done();
   });
 
-  it.skip('does not parse a exception containing a field with an invalid List type', function(done) {
+  it('does not parse a exception containing a field with an invalid List type', function(done) {
     const content = `
       exception Test {
         1: list<i16, string> test = [1,2]
@@ -715,7 +712,7 @@ describe('exceptions', function() {
     done();
   });
 
-  it.skip('does not parse a exception containing a field with a List type but invalid default', function(done) {
+  it('does not parse a exception containing a field with a List type but invalid default', function(done) {
     const content = `
       exception Test {
         1: list<i16> test = { 1: 'a', 2: 'b' }

--- a/tests/includes.js
+++ b/tests/includes.js
@@ -63,13 +63,50 @@ describe('includes', function() {
     done();
   });
 
-  // TODO: Make this pass
-  it.skip('does not parse paths wrapped in mixed-quotes (Literal)', function(done) {
+  it('does not parse paths wrapped in mixed-quotes (Literal)', function(done) {
     const content = `
         include 'test"
     `;
 
     expect(() => thriftParser(content)).toThrow();
+    done();
+  });
+
+  it('parses a double-quote inside a single-quoted value (Literal)', function(done) {
+    const content = `
+       include 'te"st'
+    `;
+
+    const expected = {
+      include: {
+        'te"st': {
+          path: 'te"st'
+        }
+      }
+    };
+
+    const ast = thriftParser(content);
+
+    expect(ast).toEqual(expected);
+    done();
+  });
+
+  it('parses a single-quote inside a double-quoted value (Literal)', function(done) {
+    const content = `
+       include "te'st"
+    `;
+
+    const expected = {
+      include: {
+        "te'st": {
+          path: "te'st"
+        }
+      }
+    };
+
+    const ast = thriftParser(content);
+
+    expect(ast).toEqual(expected);
     done();
   });
 });

--- a/tests/namespaces.js
+++ b/tests/namespaces.js
@@ -44,8 +44,7 @@ describe('namespaces', function() {
     done();
   });
 
-  // TODO: Make this pass
-  it.skip('parses a dot.separated scope', function(done) {
+  it('parses a dot.separated scope', function(done) {
     const content = `
       namespace js.noexist test
     `;

--- a/tests/services.js
+++ b/tests/services.js
@@ -126,7 +126,7 @@ describe('services', function() {
     done();
   });
 
-  it.skip('does not parse a service containing a function with invalid Map type', function(done) {
+  it('does not parse a service containing a function with invalid Map type', function(done) {
     const content = `
       service Test {
         map<i16> test()
@@ -169,7 +169,7 @@ describe('services', function() {
     done();
   });
 
-  it.skip('does not parse a service containing a function with invalid Set type', function(done) {
+  it('does not parse a service containing a function with invalid Set type', function(done) {
     const content = `
       service Test {
         set<i16, string> test()
@@ -212,7 +212,7 @@ describe('services', function() {
     done();
   });
 
-  it.skip('does not parse a service containing a function with invalid List type', function(done) {
+  it('does not parse a service containing a function with invalid List type', function(done) {
     const content = `
       service Test {
         list<i16, string> test()
@@ -844,7 +844,7 @@ describe('service function arguments', function() {
     done();
   });
 
-  it.skip('parses a service containing a function with arguments without FieldIDs', function(done) {
+  it('parses a service containing a function with arguments without FieldIDs', function(done) {
     const content = `
       service Test {
         void test(string test1, bool test2)
@@ -882,7 +882,7 @@ describe('service function arguments', function() {
     done();
   });
 
-  it.skip('parses a service containing a function with arguments with mixed FieldIDs', function(done) {
+  it('parses a service containing a function with arguments with mixed FieldIDs', function(done) {
     const content = `
       service Test {
         void test(string test1, 1: bool test2)
@@ -921,7 +921,7 @@ describe('service function arguments', function() {
     done();
   });
 
-  it.skip('parses a service containing a function with arguments using hexadecimal FieldIDs', function(done) {
+  it('parses a service containing a function with arguments using hexadecimal FieldIDs', function(done) {
     const content = `
       service Test {
         void test(0x01: string test1)
@@ -991,7 +991,7 @@ describe('service function arguments', function() {
     done();
   });
 
-  it.skip('parses a service containing a function argument with a positive FieldID with `+`', function(done) {
+  it('parses a service containing a function argument with a positive FieldID with `+`', function(done) {
     const content = `
       service Test {
         void test(+1: string test1)
@@ -1026,7 +1026,7 @@ describe('service function arguments', function() {
     done();
   });
 
-  it.skip('does not parse a service containing a function with arguments using decimal FieldIDs', function(done) {
+  it('does not parse a service containing a function with arguments using decimal FieldIDs', function(done) {
     const content = `
       service Test {
         void test(1.2: string test)
@@ -1507,7 +1507,7 @@ describe('service function throws', function() {
     done();
   });
 
-  it.skip('parses a service containing a function with throws without FieldIDs', function(done) {
+  it('parses a service containing a function with throws without FieldIDs', function(done) {
     const content = `
       service Test {
         void test() throws (TestException1 test1, TestException2 test2)
@@ -1545,7 +1545,7 @@ describe('service function throws', function() {
     done();
   });
 
-  it.skip('parses a service containing a function with throws with mixed FieldIDs', function(done) {
+  it('parses a service containing a function with throws with mixed FieldIDs', function(done) {
     const content = `
       service Test {
         void test() throws (TestException1 test1, 1: TestException2 test2)
@@ -1584,7 +1584,7 @@ describe('service function throws', function() {
     done();
   });
 
-  it.skip('parses a service containing a function with throws using hexadecimal FieldIDs', function(done) {
+  it('parses a service containing a function with throws using hexadecimal FieldIDs', function(done) {
     const content = `
       service Test {
         void test() throws (0x01: string test1)
@@ -1654,7 +1654,7 @@ describe('service function throws', function() {
     done();
   });
 
-  it.skip('parses a service containing a function with throws using a positive FieldID with `+`', function(done) {
+  it('parses a service containing a function with throws using a positive FieldID with `+`', function(done) {
     const content = `
       service Test {
         void test() throws (+1: string test1)
@@ -1689,7 +1689,7 @@ describe('service function throws', function() {
     done();
   });
 
-  it.skip('does not parse a service containing a function with throws with decimal FieldIDs', function(done) {
+  it('does not parse a service containing a function with throws with decimal FieldIDs', function(done) {
     const content = `
       service Test {
         void test() throws (1.2: string test)

--- a/tests/structs.js
+++ b/tests/structs.js
@@ -205,7 +205,7 @@ describe('structs', function() {
     done();
   });
 
-  it.skip('parses a struct containing a field with a hex FieldID', function(done) {
+  it('parses a struct containing a field with a hex FieldID', function(done) {
     const content = `
       struct Test {
         0x01: string test1
@@ -255,7 +255,7 @@ describe('structs', function() {
     done();
   });
 
-  it.skip('parses a struct containing a field with a positive FieldID with `+`', function(done) {
+  it('parses a struct containing a field with a positive FieldID with `+`', function(done) {
     const content = `
       struct Test {
         +1: string test1
@@ -266,7 +266,7 @@ describe('structs', function() {
       struct: {
         Test: [
           {
-            id: -1,
+            id: 1,
             type: 'string',
             name: 'test1'
           }
@@ -280,8 +280,7 @@ describe('structs', function() {
     done();
   });
 
-  // TODO: Remove undefined field in output
-  it.skip('parses a struct containing a field without a FieldID', function(done) {
+  it('parses a struct containing a field without a FieldID', function(done) {
     const content = `
       struct Test {
         string test1
@@ -305,7 +304,7 @@ describe('structs', function() {
     done();
   });
 
-  it.skip('parses a struct containing a field without a FieldID but with required', function(done) {
+  it('parses a struct containing a field without a FieldID but with required', function(done) {
     const content = `
       struct Test {
         required string test1
@@ -330,7 +329,7 @@ describe('structs', function() {
     done();
   });
 
-  it.skip('parses a struct containing mixed fields with/without a FieldID', function(done) {
+  it('parses a struct containing mixed fields with/without a FieldID', function(done) {
     const content = `
       struct Test {
         string test1
@@ -489,8 +488,7 @@ describe('structs', function() {
     done();
   });
 
-  // TODO: OOMs the VM
-  it.skip('does not parse a struct containing a field with invalid default', function(done) {
+  it('does not parse a struct containing a field with invalid default', function(done) {
     const content = `
       struct Test {
         1: string test = 'test
@@ -501,8 +499,7 @@ describe('structs', function() {
     done();
   });
 
-  // TODO: OOMs the VM
-  it.skip('does not parse a struct containing a field with default containing mixed quotes', function(done) {
+  it('does not parse a struct containing a field with default containing mixed quotes', function(done) {
     const content = `
       struct Test {
         1: string test = 'test"
@@ -535,7 +532,7 @@ describe('structs', function() {
     done();
   });
 
-  it.skip('does not parse a struct containing a field with decimal FieldID', function(done) {
+  it('does not parse a struct containing a field with decimal FieldID', function(done) {
     const content = `
       struct Test {
         1.2: string test
@@ -596,7 +593,7 @@ describe('structs', function() {
     done();
   });
 
-  it.skip('does not parse a struct containing a field with an invalid Map type', function(done) {
+  it('does not parse a struct containing a field with an invalid Map type', function(done) {
     const content = `
       struct Test {
         1: map<i16> test
@@ -607,7 +604,7 @@ describe('structs', function() {
     done();
   });
 
-  it.skip('does not parse a struct containing a field with a Map type but invalid default', function(done) {
+  it('does not parse a struct containing a field with a Map type but invalid default', function(done) {
     const content = `
       struct Test {
         1: map<i16, string> test = [1,2]
@@ -650,7 +647,7 @@ describe('structs', function() {
     done();
   });
 
-  it.skip('does not parse a struct containing a field with an invalid Set type', function(done) {
+  it('does not parse a struct containing a field with an invalid Set type', function(done) {
     const content = `
       struct Test {
         1: set<i16, string> test = [1,2]
@@ -661,7 +658,7 @@ describe('structs', function() {
     done();
   });
 
-  it.skip('does not parse a struct containing a field with a Set type but invalid default', function(done) {
+  it('does not parse a struct containing a field with a Set type but invalid default', function(done) {
     const content = `
       struct Test {
         1: set<i16> test = { 1: 'a', 2: 'b' }
@@ -704,7 +701,7 @@ describe('structs', function() {
     done();
   });
 
-  it.skip('does not parse a struct containing a field with an invalid List type', function(done) {
+  it('does not parse a struct containing a field with an invalid List type', function(done) {
     const content = `
       struct Test {
         1: list<i16, string> test = [1,2]
@@ -715,7 +712,7 @@ describe('structs', function() {
     done();
   });
 
-  it.skip('does not parse a struct containing a field with a List type but invalid default', function(done) {
+  it('does not parse a struct containing a field with a List type but invalid default', function(done) {
     const content = `
       struct Test {
         1: list<i16> test = { 1: 'a', 2: 'b' }

--- a/tests/typedefs.js
+++ b/tests/typedefs.js
@@ -109,7 +109,7 @@ describe('typedefs', function() {
     done();
   });
 
-  it.skip('does not parse an invalid Map typedef', function(done) {
+  it('does not parse an invalid Map typedef', function(done) {
     const content = `
       typedef map<string> Test;
     `;
@@ -149,7 +149,7 @@ describe('typedefs', function() {
     done();
   });
 
-  it.skip('does not parse an invalid Set typedef', function(done) {
+  it('does not parse an invalid Set typedef', function(done) {
     const content = `
       typedef set<string, string> Test;
     `;
@@ -189,7 +189,7 @@ describe('typedefs', function() {
     done();
   });
 
-  it.skip('does not parse an invalid List typedef', function(done) {
+  it('does not parse an invalid List typedef', function(done) {
     const content = `
       typedef list<string, string> Test;
     `;

--- a/tests/unions.js
+++ b/tests/unions.js
@@ -205,7 +205,7 @@ describe('unions', function() {
     done();
   });
 
-  it.skip('parses a union containing a field with a hex FieldID', function(done) {
+  it('parses a union containing a field with a hex FieldID', function(done) {
     const content = `
       union Test {
         0x01: string test1
@@ -255,7 +255,7 @@ describe('unions', function() {
     done();
   });
 
-  it.skip('parses a union containing a field with a positive FieldID with `+`', function(done) {
+  it('parses a union containing a field with a positive FieldID with `+`', function(done) {
     const content = `
       union Test {
         +1: string test1
@@ -266,7 +266,7 @@ describe('unions', function() {
       union: {
         Test: [
           {
-            id: -1,
+            id: 1,
             type: 'string',
             name: 'test1'
           }
@@ -280,8 +280,7 @@ describe('unions', function() {
     done();
   });
 
-  // TODO: Remove undefined field in output
-  it.skip('parses a union containing a field without a FieldID', function(done) {
+  it('parses a union containing a field without a FieldID', function(done) {
     const content = `
       union Test {
         string test1
@@ -305,7 +304,7 @@ describe('unions', function() {
     done();
   });
 
-  it.skip('parses a union containing a field without a FieldID but with required', function(done) {
+  it('parses a union containing a field without a FieldID but with required', function(done) {
     const content = `
       union Test {
         required string test1
@@ -330,7 +329,7 @@ describe('unions', function() {
     done();
   });
 
-  it.skip('parses a union containing mixed fields with/without a FieldID', function(done) {
+  it('parses a union containing mixed fields with/without a FieldID', function(done) {
     const content = `
       union Test {
         string test1
@@ -489,8 +488,7 @@ describe('unions', function() {
     done();
   });
 
-  // TODO: OOMs the VM
-  it.skip('does not parse a union containing a field with invalid default', function(done) {
+  it('does not parse a union containing a field with invalid default', function(done) {
     const content = `
       union Test {
         1: string test = 'test
@@ -501,8 +499,7 @@ describe('unions', function() {
     done();
   });
 
-  // TODO: OOMs the VM
-  it.skip('does not parse a union containing a field with default containing mixed quotes', function(done) {
+  it('does not parse a union containing a field with default containing mixed quotes', function(done) {
     const content = `
       union Test {
         1: string test = 'test"
@@ -535,7 +532,7 @@ describe('unions', function() {
     done();
   });
 
-  it.skip('does not parse a union containing a field with decimal FieldID', function(done) {
+  it('does not parse a union containing a field with decimal FieldID', function(done) {
     const content = `
       union Test {
         1.2: string test
@@ -596,7 +593,7 @@ describe('unions', function() {
     done();
   });
 
-  it.skip('does not parse a union containing a field with an invalid Map type', function(done) {
+  it('does not parse a union containing a field with an invalid Map type', function(done) {
     const content = `
       union Test {
         1: map<i16> test
@@ -607,7 +604,7 @@ describe('unions', function() {
     done();
   });
 
-  it.skip('does not parse a union containing a field with a Map type but invalid default', function(done) {
+  it('does not parse a union containing a field with a Map type but invalid default', function(done) {
     const content = `
       union Test {
         1: map<i16, string> test = [1,2]
@@ -650,7 +647,7 @@ describe('unions', function() {
     done();
   });
 
-  it.skip('does not parse a union containing a field with an invalid Set type', function(done) {
+  it('does not parse a union containing a field with an invalid Set type', function(done) {
     const content = `
       union Test {
         1: set<i16, string> test = [1,2]
@@ -661,7 +658,7 @@ describe('unions', function() {
     done();
   });
 
-  it.skip('does not parse a union containing a field with a Set type but invalid default', function(done) {
+  it('does not parse a union containing a field with a Set type but invalid default', function(done) {
     const content = `
       union Test {
         1: set<i16> test = { 1: 'a', 2: 'b' }
@@ -704,7 +701,7 @@ describe('unions', function() {
     done();
   });
 
-  it.skip('does not parse a union containing a field with an invalid List type', function(done) {
+  it('does not parse a union containing a field with an invalid List type', function(done) {
     const content = `
       union Test {
         1: list<i16, string> test = [1,2]
@@ -715,7 +712,7 @@ describe('unions', function() {
     done();
   });
 
-  it.skip('does not parse a union containing a field with a List type but invalid default', function(done) {
+  it('does not parse a union containing a field with a List type but invalid default', function(done) {
     const content = `
       union Test {
         1: list<i16> test = { 1: 'a', 2: 'b' }


### PR DESCRIPTION
Sorry for the delay on getting these sent in, took longer than I thought to get reviewed.

This PR contains the following changes that fix the skipped tests in my previously submitted tests:
* Support dot-separated namespace scopes
* Fix mixed-quote termination bug
* Fix incorrect parsing of invalid Map/Set/List types
* Fix for const erroneously parsing without a value
* Fix for OOM error when parsing an unterminated string
* Verify that const with Map/Set/List types are parsed properly
* Ensure Map/Set/List values match type definition (possibly controversial)
* Add tests for semi-colon ListSeparator in List/Map/Set types
* Avoid attaching an undefined value to enums without values
* Ensure enum values are only integers or hexadecimal (likely needs to be fine-tuned more)
* Add support for hexadecimal struct FieldIDs
* Ensure structs with + symbol can be parsed
* Avoid attaching an undefined id to struct fields without an id
* Ensure struct string defaults are parsed correctly
* Ensure structs will not parse if it contains a decimal FieldID
* Ensure structs handle Set/List/Map types and values correctly
* Ensure exceptions are handled the same as structs
* Ensure services handle Set/List/Map types correctly
* Ensure function argument FieldIDs are handled correctly
* Ensure function throw FieldIDs are handled correctly
* Ensure unions are handled the same as structs