### PR TITLE
Fix the `Services` type definition - missing the `functions` key

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -50,7 +50,9 @@ type Exceptions = {
 
 type Services = {
   [serviceName: string]: {
-    [methodName: string]: Method,
+    functions: {
+      [methodName: string]: Method,
+    },
   },
 }
 


### PR DESCRIPTION
Hi @phated ,

The `Service` AST node has a unique `functions` key.